### PR TITLE
Update muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggs…

### DIFF
--- a/nrel_5mw/g1/muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggsize.xml
+++ b/nrel_5mw/g1/muelu-cheby2er12-drop0.02-smoo-rebaltarg10k-explR-rebalPR-aggsize.xml
@@ -5,8 +5,19 @@
   <Parameter name="transpose: use implicit"                 type="bool"     value="false"/>
   <Parameter name="repartition: rebalance P and R"          type="bool"     value="true"/>
 
-  <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
-  <ParameterList    name="smoother: params">
+  <Parameter        name="smoother: pre or post"            type="string"   value="both"/>
+
+  <Parameter        name="smoother: pre type"              type="string"   value="CHEBYSHEV"/>
+  <ParameterList    name="smoother: pre params">
+    <Parameter      name="chebyshev: degree"                    type="int"      value="1"/>>
+    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="12"/>
+    <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+    <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+    <Parameter      name="chebyshev: eigenvalue max iterations" type="int"      value="10"/>
+  </ParameterList>
+
+  <Parameter        name="smoother: post type"              type="string"   value="CHEBYSHEV"/>
+  <ParameterList    name="smoother: post params">
     <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>>
     <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="12"/>
     <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>


### PR DESCRIPTION
Reducing the number of AMG V-cycle pre-smooth sweeps leads to over 50% drop in solver time
and a 10-20% reduction in model run time. Tests to date on ABL and NREL 5WM G1 with
Chebyshev smoother and Trilinos solver stack (on Eagle and Cori). Wider tests with C-AMG
(in Matlab) on AOA4 air foil and other matrices confirm the post-sweep reduces the residual
error more effectively. Results remain unchanged. Timing below (and iterations):

/global/cscratch1/sd/sthomas1/g1> fgrep "solve --" nrel_5mw_g1-muelu-128-gmres-cheb-1.log
            solve --       avg: 0     min: 0     max: 0
            solve --       avg: 488.069     min: 486.7     max: 489.225
            solve --       avg: **352.963**     min: 352.942     max: 352.972
linear iterations --  	avg: 18.75 	min: 11 	max: 26
linear iterations --  	avg: **19.85** 	min: 9 	max: 32
/global/cscratch1/sd/sthomas1/g1> fgrep "solve --" nrel_5mw_g1-muelu-128-gmres-cheby-post-1.log
            solve --       avg: 0     min: 0     max: 0
            solve --       avg: 488.481     min: 487.096     max: 489.641
            solve --       avg: **160.619**     min: 160.603     max: 160.627
linear iterations --  	avg: 18.75 	min: 11 	max: 26
linear iterations --  	avg: **19.8** 	min: 10 	max: 31