### PR TITLE
ablNeutral: add required wall function

### DIFF
--- a/ablNeutralEdge/input.yaml
+++ b/ablNeutralEdge/input.yaml
@@ -150,12 +150,6 @@ realms:
       target_name: lower
       wall_user_data:
         velocity: [0,0,0]
-        use_abl_wall_function: yes
-        heat_flux: 0.0
-        reference_temperature: 300.0
-        roughness_height: 0.1
-        gravity_vector_component: 3
-
         abl_wall_function:
           surface_heating_table:
             - [     0.0, 0.00, 300.0, 1.0]

--- a/ablNeutralEdge/input.yaml
+++ b/ablNeutralEdge/input.yaml
@@ -156,6 +156,22 @@ realms:
         roughness_height: 0.1
         gravity_vector_component: 3
 
+        abl_wall_function:
+          surface_heating_table:
+            - [     0.0, 0.00, 300.0, 1.0]
+            - [999999.9, 0.00, 300.0, 1.0]
+          reference_temperature: 300.0
+          roughness_height: 0.1
+          kappa: 0.4
+          beta_m: 5.0
+          beta_h: 5.0
+          gamma_m: 16.0
+          gamma_h: 16.0
+          gravity_vector_component: 3
+          monin_obukhov_averaging_type: planar
+          fluctuation_model: Moeng
+          fluctuating_temperature_ref: surface
+
     solution_options:
       name: myOptions
       turbulence_model: ksgs


### PR DESCRIPTION
The ABL neutral simulation requires a wall function (see https://github.com/Exawind/nalu-wind/blob/master/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.yaml#L152).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exawind/solver-performance/27)
<!-- Reviewable:end -->
